### PR TITLE
Correction typo constructeur Point3D

### DIFF
--- a/Point3D.h
+++ b/Point3D.h
@@ -2,14 +2,14 @@
 #include "Point.h"
 
 namespace points{
-    class Point2D : public Point{
+    class Point3D : public Point{
         private :
             double x;
             double y;
 
         public :
-            Point2D(double,double);
-            Point2D(*Point);
+            Point3D(double,double);
+            Point3D(*Point);
             double get_x() const override;
             double get_y() const override;
             double get_z() const override;


### PR DESCRIPTION
Modification de la classe Points3D.

Correction de la typo sur le constructeur dans le fichier Points3D.h